### PR TITLE
added PrivatePage.spec.js

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,7 +54,6 @@
     "axios": "^0.8.1",
     "counterpart": "^0.17.1",
     "deep-equal": "^1.0.1",
-    "halogen": "^0.1.10",
     "history": "1.17.0",
     "isdev": "^1.0.1",
     "react": "^0.14.3",

--- a/frontend/src/reducers/authentication.js
+++ b/frontend/src/reducers/authentication.js
@@ -17,7 +17,8 @@ const ERROR_MESSAGE = 'authentication/ERROR_MESSAGE';
 const initialState = {
   isAuthenticated: false,
   username: null,
-  errorMessage: null
+  errorMessage: null,
+  loading: false,
 };
 
 // Reducer

--- a/frontend/src/router/privateRoute.js
+++ b/frontend/src/router/privateRoute.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { redirectToLoginWithMessage } from 'reducers/authentication';
-import { ScaleLoader } from 'halogen';
 import { connect } from 'react-redux';
 
 const mapStateToProps = (state) => ({
@@ -32,8 +31,8 @@ const privateRoute = (Wrapped) => connect(mapStateToProps, mapDispatchToProps)(c
     const {loading, isAuthenticated} = this.props;
     if (loading || !isAuthenticated) {
       return (
-        <div className="center">
-          <ScaleLoader color="#000" size="24px"/>
+        <div className="center loader">
+          <div>Loading...</div>
         </div>
       );
     }

--- a/frontend/test/components/PrivatePage.spec.js
+++ b/frontend/test/components/PrivatePage.spec.js
@@ -1,0 +1,29 @@
+import { describeWithDOM, mount } from 'enzyme';
+import { expect } from '../utils/chai';
+
+import React from 'react';
+import privateRoute from 'router/privateRoute';
+import { PrivatePage } from 'ui/PrivatePage';
+
+import initStore from 'config/store';
+
+describeWithDOM('PrivatePage', () => {
+
+  it('should render loader when not authenticated', () => {
+    const WrappedRoute = privateRoute(PrivatePage);
+    const store = initStore();
+    const component = mount(<WrappedRoute store={store} />);
+
+    expect(store.getState().routing.path).to.be.equal('/login');
+    expect(component.find('.loader')).to.have.length(1);
+  });
+
+  it('should render the page when authenticated', () => {
+    const WrappedRoute = privateRoute(PrivatePage);
+    const store = initStore({authentication: {isAuthenticated: true}});
+    const component = mount(<WrappedRoute store={store} />);
+
+    expect(component.find('.loader')).to.have.length(0);
+  });
+
+});


### PR DESCRIPTION
Added a test for private routes to check the correct rendering states
when authenticated / not authenticated.

The test also checks if the routing changes to `/login` when a
private page is accessed unauthenticated.

I removed `halogen` in the process, as its a) not compatible with
`enzyme`s `describeWithDom` api, and b) works not in IE8.

If you want to stick with halogen, i can try to make it work, but it was simply
faster this way and it's not really necessary for the starter imho...