### PR TITLE
Fix jeet dependency issue

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "html-webpack-plugin": "^2.15.0",
     "http-proxy-middleware": "^0.13.0",
-    "jeet": "^6.1.2",
+    "jeet": "6.1.2",
     "jsdom-global": "^1.7.0",
     "json-loader": "^0.5.4",
     "mocha": "^2.4.5",


### PR DESCRIPTION
Issue #28 is caused by a problem with the frontend dependency _jeet_

This issue is explained in more detail [here](https://github.com/mojotech/jeet/issues/129).

By statically pegging the version of jeet to 6.1.2 the issue is mitigated.